### PR TITLE
Logging improvement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.ghost4j</groupId>
     <artifactId>ghost4j</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.0.5-SNAPSHOT</version>
 
     <name>Ghost4J</name>
     <description>Java wrapper for Ghostscript API. Official ${project.name} build of the
@@ -100,27 +100,9 @@
             <version>4.1.0</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>jmxtools</artifactId>
-                    <groupId>com.sun.jdmk</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>mail</artifactId>
-                    <groupId>javax.mail</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>jmxri</artifactId>
-                    <groupId>com.sun.jmx</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>jms</artifactId>
-                    <groupId>javax.jms</groupId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>
@@ -336,6 +318,8 @@
                         </goals>
                     </execution>
                 </executions>
+                <!-- A ENLEVER -->
+                <configuration><skip>true</skip></configuration>
             </plugin>
 
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -100,9 +100,9 @@
             <version>4.1.0</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.17.1</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.32</version>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>
@@ -318,8 +318,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <!-- A ENLEVER -->
-                <configuration><skip>true</skip></configuration>
             </plugin>
 
         </plugins>

--- a/src/main/java/org/ghost4j/AbstractRemoteComponent.java
+++ b/src/main/java/org/ghost4j/AbstractRemoteComponent.java
@@ -12,10 +12,10 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.ghost4j.util.JavaFork;
 import org.ghost4j.util.NetworkUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Abstract remote converter component. Used as base class for remote
@@ -26,9 +26,10 @@ import org.ghost4j.util.NetworkUtil;
 public abstract class AbstractRemoteComponent extends AbstractComponent {
 
     /**
-     * Log4J logger used to log messages.
+     * Slf4j logger used to log messages.
      */
-    private Logger logger = LogManager.getLogger(AbstractRemoteComponent.class.getName());
+    private Logger logger = LoggerFactory.getLogger(AbstractRemoteComponent.class.getName());
+    //private Logger logger = LogManager.getLogger(AbstractRemoteComponent.class.getName());
 
     /**
      * Maximum number of parallel processes allowed for the converter.

--- a/src/main/java/org/ghost4j/AbstractRemoteComponent.java
+++ b/src/main/java/org/ghost4j/AbstractRemoteComponent.java
@@ -12,7 +12,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.ghost4j.util.JavaFork;
 import org.ghost4j.util.NetworkUtil;
 
@@ -27,8 +28,7 @@ public abstract class AbstractRemoteComponent extends AbstractComponent {
     /**
      * Log4J logger used to log messages.
      */
-    private Logger logger = Logger.getLogger(AbstractRemoteComponent.class
-	    .getName());
+    private Logger logger = LogManager.getLogger(AbstractRemoteComponent.class.getName());
 
     /**
      * Maximum number of parallel processes allowed for the converter.

--- a/src/main/java/org/ghost4j/AbstractRemoteComponent.java
+++ b/src/main/java/org/ghost4j/AbstractRemoteComponent.java
@@ -26,10 +26,9 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractRemoteComponent extends AbstractComponent {
 
     /**
-     * Slf4j logger used to log messages.
+     * Logger used to log messages.
      */
     private Logger logger = LoggerFactory.getLogger(AbstractRemoteComponent.class.getName());
-    //private Logger logger = LogManager.getLogger(AbstractRemoteComponent.class.getName());
 
     /**
      * Maximum number of parallel processes allowed for the converter.

--- a/src/main/java/org/ghost4j/Ghostscript.java
+++ b/src/main/java/org/ghost4j/Ghostscript.java
@@ -12,7 +12,7 @@ import java.io.OutputStream;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
-import org.apache.log4j.Level;
+import org.apache.logging.log4j.Level;
 import org.ghost4j.display.DisplayCallback;
 import org.ghost4j.display.DisplayData;
 

--- a/src/main/java/org/ghost4j/Ghostscript.java
+++ b/src/main/java/org/ghost4j/Ghostscript.java
@@ -12,12 +12,12 @@ import java.io.OutputStream;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
-import org.apache.logging.log4j.Level;
 import org.ghost4j.display.DisplayCallback;
 import org.ghost4j.display.DisplayData;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
+import org.slf4j.event.Level;
 
 /**
  * Class representing the Ghostscript interpreter.

--- a/src/main/java/org/ghost4j/GhostscriptLoggerOutputStream.java
+++ b/src/main/java/org/ghost4j/GhostscriptLoggerOutputStream.java
@@ -10,8 +10,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Class used to wrap Ghostscript interpreter log messages in Log4J messages.
@@ -52,8 +53,7 @@ public class GhostscriptLoggerOutputStream extends OutputStream {
      *            Defines the log level of outputed messages.
      */
     public GhostscriptLoggerOutputStream(Level level) {
-
-	logger = Logger.getLogger(LOGGER_NAME);
+    logger = LogManager.getLogger(LOGGER_NAME);
 	baos = new ByteArrayOutputStream();
 	this.level = level;
     }

--- a/src/main/java/org/ghost4j/GhostscriptLoggerOutputStream.java
+++ b/src/main/java/org/ghost4j/GhostscriptLoggerOutputStream.java
@@ -10,12 +10,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 /**
- * Class used to wrap Ghostscript interpreter log messages in Log4J messages.
+ * Class used to wrap Ghostscript interpreter log messages in Slf4j messages.
  * 
  * @author Gilles Grousset (gi.grousset@gmail.com)
  */
@@ -37,12 +37,12 @@ public class GhostscriptLoggerOutputStream extends OutputStream {
     private ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
     /**
-     * Log4J logger used to log messages.
+     * Logger used to log messages.
      */
     private Logger logger;
 
     /**
-     * Log level used when outputing messages to the Log4J logger.
+     * Log level used when outputing messages to the logger.
      */
     private Level level;
 
@@ -53,14 +53,14 @@ public class GhostscriptLoggerOutputStream extends OutputStream {
      *            Defines the log level of outputed messages.
      */
     public GhostscriptLoggerOutputStream(Level level) {
-    logger = LogManager.getLogger(LOGGER_NAME);
+    logger = LoggerFactory.getLogger(LOGGER_NAME);
 	baos = new ByteArrayOutputStream();
 	this.level = level;
     }
 
     /**
      * Write method that stores data to write in the ByteArrayOutputStream and
-     * sends messages to the Log4J logger when a line ends.
+     * sends messages to the logger when a line ends.
      * 
      * @param b
      *            Byte to write
@@ -69,7 +69,11 @@ public class GhostscriptLoggerOutputStream extends OutputStream {
     public void write(int b) throws IOException {
 
 	if (b == LINE_END) {
-	    logger.log(level, baos.toString());
+	    if (level == Level.INFO) {
+            logger.info(baos.toString());
+        } else if (level == Level.ERROR) {
+            logger.error(baos.toString());
+        }
 	    baos.reset();
 	} else {
 	    baos.write(b);


### PR DESCRIPTION
These improvements change the logging from Log4j 1.2.17 (with some critical vulnerabilities like CVE-2021-4104) to a Slf4j facade. This should allow owners of projects using this library to select the logging framework they want to use (logback-classic, log4j, ...).